### PR TITLE
Feature/calculate cost

### DIFF
--- a/dashboard/apps/prototype/management/commands/calculate.py
+++ b/dashboard/apps/prototype/management/commands/calculate.py
@@ -58,9 +58,15 @@ class Command(BaseCommand):
             logger.info('-' * 20)
             print_person(person)
             for task in person_to_task[person]:
-                time_cost, money_cost = print_task(task, start_date, end_date)
-                total_time += time_cost
-                total_money += money_cost
+                try:
+                    time_cost, money_cost = print_task(
+                        task, start_date, end_date)
+                except ValueError as exc:
+                    logger.warning('found data problem in task %s', task)
+                    continue
+                else:
+                    total_time += time_cost
+                    total_money += money_cost
         logger.info('-' * 20)
         logger.info('total spendings {:.5f} man days, £ {:.2f}'.format(
             total_time, total_money))

--- a/dashboard/apps/prototype/management/commands/calculate.py
+++ b/dashboard/apps/prototype/management/commands/calculate.py
@@ -28,6 +28,27 @@ class Command(BaseCommand):
         parser.add_argument('-a', '--areas', nargs='*', type=str)
         parser.add_argument('-n', '--names', nargs='*', type=str)
 
+    @staticmethod
+    def _print_tasks(person_to_task, start_date, end_date):
+        total_time = 0
+        total_money = 0
+        for person in person_to_task:
+            logger.info('-' * 20)
+            print_person(person)
+            for task in person_to_task[person]:
+                try:
+                    time_cost, money_cost = print_task(
+                        task, start_date, end_date)
+                except ValueError:
+                    logger.warning('found data problem in task %s', task)
+                    continue
+                else:
+                    total_time += time_cost
+                    total_money += money_cost
+        logger.info('-' * 20)
+        logger.info('total spendings {:.5f} man days, £ {:.2f}'.format(
+            total_time, total_money))
+
     def handle(self, *args, **options):
         start_date = options['start_date']
         end_date = options['end_date']
@@ -52,21 +73,4 @@ class Command(BaseCommand):
         person_to_task = {}
         for task in tasks:
             person_to_task.setdefault(task.person, []).append(task)
-        total_time = 0
-        total_money = 0
-        for person in person_to_task:
-            logger.info('-' * 20)
-            print_person(person)
-            for task in person_to_task[person]:
-                try:
-                    time_cost, money_cost = print_task(
-                        task, start_date, end_date)
-                except ValueError as exc:
-                    logger.warning('found data problem in task %s', task)
-                    continue
-                else:
-                    total_time += time_cost
-                    total_money += money_cost
-        logger.info('-' * 20)
-        logger.info('total spendings {:.5f} man days, £ {:.2f}'.format(
-            total_time, total_money))
+        self._print_tasks(person_to_task, start_date, end_date)

--- a/dashboard/apps/prototype/management/commands/calculate.py
+++ b/dashboard/apps/prototype/management/commands/calculate.py
@@ -52,8 +52,15 @@ class Command(BaseCommand):
         person_to_task = {}
         for task in tasks:
             person_to_task.setdefault(task.person, []).append(task)
+        total_time = 0
+        total_money = 0
         for person in person_to_task:
             logger.info('-' * 20)
             print_person(person)
             for task in person_to_task[person]:
-                print_task(task, start_date, end_date)
+                time_cost, money_cost = print_task(task, start_date, end_date)
+                total_time += time_cost
+                total_money += money_cost
+        logger.info('-' * 20)
+        logger.info('total spendings {:.5f} man days, £ {:.2f}'.format(
+            total_time, total_money))

--- a/dashboard/apps/prototype/management/commands/helpers.py
+++ b/dashboard/apps/prototype/management/commands/helpers.py
@@ -63,10 +63,13 @@ def print_task(task, start_date, end_date, padding='  '):
     lines.append('task start: {}, end: {}, total: {:.5f} working days'.format(
         task.start_date, task.end_date, task.days))
     time_spent = task.time_spent(start_date, end_date)
+    money_spent = task.money_spent(start_date, end_date)
     lines.append(
-        'time spent in this time frame: {:.5f} days'.format(time_spent))
+        'spendings in this time frame: {:.5f} days, £{:.2f}'.format(
+            time_spent, money_spent))
     for index, line in enumerate(lines):
         if index == 0:
             logger.info('%s- %s', padding, line)
         else:
             logger.info('%s  %s', padding, line)
+    return time_spent, money_spent

--- a/dashboard/apps/prototype/management/commands/sync.py
+++ b/dashboard/apps/prototype/management/commands/sync.py
@@ -166,6 +166,11 @@ def sync_tasks(data_dir):
             start_date = datetime.strptime(
                 task['start_date'], '%Y-%m-%d').date()
             end_date = datetime.strptime(task['end_date'], '%Y-%m-%d').date()
+            if start_date > end_date:
+                logger.warning(
+                    'found task with start date greater than end date. skip!'
+                    ' task data %s', task)
+                continue
             useful_data = {
                 'name': task['task_name'],
                 'float_id': task['task_id'],

--- a/dashboard/apps/prototype/models.py
+++ b/dashboard/apps/prototype/models.py
@@ -199,17 +199,17 @@ class Task(models.Model):
         if end_date <= self.start_date:
             start_date = end_date
 
-        slice = get_overlap(
+        timewindow = get_overlap(
             (start_date, end_date), (self.start_date, self.end_date))
 
-        if not slice:
+        if not timewindow:
             return 0
-        if slice == (self.start_date, self.end_date):
+        if timewindow == (self.start_date, self.end_date):
             return self.days
 
-        slice_workdays = get_workdays(*slice)
+        timewindow_workdays = get_workdays(*timewindow)
 
-        return Decimal(slice_workdays) / Decimal(self.workdays) * self.days
+        return Decimal(timewindow_workdays) / Decimal(self.workdays) * self.days
 
     def money_spent(self, start_date=None, end_date=None):
         """
@@ -221,15 +221,15 @@ class Task(models.Model):
         start_date = start_date or self.start_date
         end_date = end_date or self.end_date
 
-        slice = get_overlap(
+        timewindow = get_overlap(
             (start_date, end_date), (self.start_date, self.end_date))
 
-        if not slice:
+        if not timewindow:
             return 0
 
-        rate = self.person.rate_between(*slice)
+        rate = self.person.rate_between(*timewindow)
         if not rate:
             return 0
-        slice_workdays = get_workdays(*slice)
-        days = Decimal(slice_workdays) / Decimal(self.workdays) * self.days
+        timewindow_workdays = get_workdays(*timewindow)
+        days = Decimal(timewindow_workdays) / Decimal(self.workdays) * self.days
         return rate * days

--- a/dashboard/apps/prototype/models.py
+++ b/dashboard/apps/prototype/models.py
@@ -6,7 +6,7 @@ from django.db import models
 from django.contrib.postgres.fields import JSONField
 from django.utils.translation import ugettext_lazy
 
-from dashboard.libs.date_tools import get_workdays
+from dashboard.libs.date_tools import get_workdays, get_overlap
 from dashboard.libs.rate_converter import RATE_TYPES, RateConverter, \
     dec_workdays, average_rate_from_segments
 
@@ -193,20 +193,14 @@ class Task(models.Model):
         start_date = start_date or self.start_date
         end_date = end_date or self.end_date
 
-        if start_date < self.start_date:
-            if end_date < self.start_date:
-                slice = None
-            elif end_date <= self.end_date:
-                slice = self.start_date, end_date
-            else:
-                slice = self.start_date, self.end_date
-        elif start_date <= self.end_date:
-            if end_date <= self.end_date:
-                slice = start_date, end_date
-            else:
-                slice = start_date, self.end_date
-        else:
-            slice = None
+        # sanitise the time window
+        if start_date >= self.end_date:
+            end_date = start_date
+        if end_date <= self.start_date:
+            start_date = end_date
+
+        slice = get_overlap(
+            (start_date, end_date), (self.start_date, self.end_date))
 
         if not slice:
             return 0
@@ -216,3 +210,26 @@ class Task(models.Model):
         slice_workdays = get_workdays(*slice)
 
         return Decimal(slice_workdays) / Decimal(self.workdays) * self.days
+
+    def money_spent(self, start_date=None, end_date=None):
+        """
+        get the money spent on the task during a time window.
+        :param start_date: start date of the time window, a date object
+        :param end_date: end date of the time window, a date object
+        :return: cost in pound, a decimal
+        """
+        start_date = start_date or self.start_date
+        end_date = end_date or self.end_date
+
+        slice = get_overlap(
+            (start_date, end_date), (self.start_date, self.end_date))
+
+        if not slice:
+            return 0
+
+        rate = self.person.rate_between(*slice)
+        if not rate:
+            return 0
+        slice_workdays = get_workdays(*slice)
+        days = Decimal(slice_workdays) / Decimal(self.workdays) * self.days
+        return rate * days

--- a/dashboard/libs/date_tools.py
+++ b/dashboard/libs/date_tools.py
@@ -49,3 +49,37 @@ def get_workdays_list(start_date, end_date):
         d.weekday() < 5 and d.strftime('%Y-%m-%d') not in bank_holidays]
 
     return workdays
+
+
+def get_overlap(time_window0, time_window1):
+    """
+    get the overlap of two time windows
+    :param time_window0: a tuple of date/datetime objects represeting the
+    start and end of a time window
+    :param time_window1: a tuple of date/datetime objects represeting the
+    start and end of a time window
+    :return: a tuple of date/datetime objects represeting the start and
+    end of a time window or None if no overlapping found
+    """
+    sdate0, edate0 = time_window0
+    sdate1, edate1 = time_window1
+
+    error = 'start date {} is greater than end date {}'
+    assert sdate0 <= edate0, error.format(sdate0, edate0)
+    assert sdate1 <= edate1, error.format(sdate1, edate1)
+
+    if sdate1 < sdate0:
+        if edate1 < sdate0:
+            overlap = None
+        elif edate1 <= edate0:
+            overlap = sdate0, edate1
+        else:
+            overlap = sdate0, edate0
+    elif sdate1 <= edate0:
+        if edate1 <= edate0:
+            overlap = sdate1, edate1
+        else:
+            overlap = sdate1, edate0
+    else:
+        overlap = None
+    return overlap

--- a/dashboard/libs/date_tools.py
+++ b/dashboard/libs/date_tools.py
@@ -60,13 +60,16 @@ def get_overlap(time_window0, time_window1):
     start and end of a time window
     :return: a tuple of date/datetime objects represeting the start and
     end of a time window or None if no overlapping found
+    :raise: ValueError
     """
     sdate0, edate0 = time_window0
     sdate1, edate1 = time_window1
 
     error = 'start date {} is greater than end date {}'
-    assert sdate0 <= edate0, error.format(sdate0, edate0)
-    assert sdate1 <= edate1, error.format(sdate1, edate1)
+    if edate0 < sdate0:
+        raise ValueError(error.format(sdate0, edate0))
+    if edate1 < sdate1:
+        raise ValueError(error.format(sdate1, edate1))
 
     if sdate1 < sdate0:
         if edate1 < sdate0:

--- a/dashboard/libs/rate_converter.py
+++ b/dashboard/libs/rate_converter.py
@@ -129,7 +129,7 @@ class RateConverter():
         param: end_date: date - object end of time period for average
         return: Decimal object - average day rate
         """
-        if self.rate_type is RATE_TYPES.DAY:
+        if self.rate_type == RATE_TYPES.DAY:
             return self.rate
 
         if not on:
@@ -146,7 +146,7 @@ class RateConverter():
         param: end_date: date - object end of time period for average
         return: Decimal object - average day rate
         """
-        if self.rate_type is RATE_TYPES.DAY:
+        if self.rate_type == RATE_TYPES.DAY:
             return self.rate
 
         total_workdays = dec_workdays(start_date, end_date)

--- a/dashboard/libs/tests/test_rate_converter.py
+++ b/dashboard/libs/tests/test_rate_converter.py
@@ -24,6 +24,11 @@ from ..rate_converter import RateConverter, RATE_TYPES
     (date(2014, 1, 1), '60000', RATE_TYPES.YEAR, '237.15'),  # 2014
     (date(2015, 1, 1), '60000', RATE_TYPES.YEAR, '237.15'),  # 2015
     (date(2016, 1, 1), '60000', RATE_TYPES.YEAR, '237.15'),  # 2016
+
+    # use original values
+    (date(2016, 1, 1), '500', RATE_TYPES.DAY.original_value, '500'),
+    (date(2016, 12, 1), '4600', RATE_TYPES.MONTH.original_value, '230'),
+    (date(2016, 1, 1), '60000', RATE_TYPES.YEAR.original_value, '237.15'),
 ])
 def test_rate_at_certain_time(on, rate, rate_type, expected):
     converter = RateConverter(Decimal(rate), rate_type)


### PR DESCRIPTION
- the calculate command now returns the total man days and cost. this is an example usage of calculating the cost on project `CLA Public` in the time period of `1st May 16` to `31st May 16` with generated rates.
- deal with float data error where start date is greater than end date
- gentle refactoring
