### PR TITLE
Feature/people status

### DIFF
--- a/dashboard/apps/prototype/admin.py
+++ b/dashboard/apps/prototype/admin.py
@@ -33,14 +33,16 @@ class IsCivilServantFilter(admin.SimpleListFilter):
             return queryset.filter(is_contractor=False)
         elif self.value() == 'no':
             return queryset.filter(is_contractor=True)
+        else:
+            return queryset
 
 
-class IsCurrentFilter(admin.SimpleListFilter):
+class IsCurrentStaffFilter(admin.SimpleListFilter):
     """
     this filter shows `is_current=True` by default
     """
     title = 'is current staff?'
-    parameter_name = 'is_current'
+    parameter_name = 'is_current_staff'
 
     def lookups(self, request, model_admin):
         return (
@@ -50,7 +52,7 @@ class IsCurrentFilter(admin.SimpleListFilter):
         )
 
     def choices(self, cl):
-        for lookup, title in self.lookup_choices:
+        for lookup, title in self.lookup_choices:  # pragma: no cover
             yield {
                 'selected': self.value() == lookup,
                 'query_string': cl.get_query_string({
@@ -64,6 +66,8 @@ class IsCurrentFilter(admin.SimpleListFilter):
             return queryset.filter(is_current=True)
         elif self.value() == 'no':
             return queryset.filter(is_current=False)
+        else:
+            return queryset
 
 
 class PersonAdmin(ReadOnlyAdmin):
@@ -73,7 +77,7 @@ class PersonAdmin(ReadOnlyAdmin):
     list_display = ('avatar_tag', 'name', 'job_title',
                     'contractor_civil_servant', 'is_current')
     search_fields = ('name', 'job_title')
-    list_filter = (IsCivilServantFilter, IsCurrentFilter)
+    list_filter = (IsCivilServantFilter, IsCurrentStaffFilter)
     exclude = ['raw_data']
 
     def avatar_tag(self, obj):  # pragma: no cover

--- a/dashboard/apps/prototype/admin.py
+++ b/dashboard/apps/prototype/admin.py
@@ -68,6 +68,7 @@ class IsCurrentFilter(admin.SimpleListFilter):
 
 class PersonAdmin(ReadOnlyAdmin):
     inlines = [RateInline]
+    ordering = ('name',)
     readonly_fields = ('avatar_tag', )
     list_display = ('avatar_tag', 'name', 'job_title',
                     'contractor_civil_servant', 'is_current')

--- a/dashboard/apps/prototype/admin.py
+++ b/dashboard/apps/prototype/admin.py
@@ -14,6 +14,27 @@ class RateInline(FinancePermissions, admin.TabularInline):
     extra = 0
 
 
+class IsCivilServantFilter(admin.SimpleListFilter):
+    """
+    this filter shows labels of civil servant or contractor
+    instead of boolean flags
+    """
+    title = 'civil servant | contractor'
+    parameter_name = 'is_civil_servant'
+
+    def lookups(self, request, model_admin):
+        return (
+            ('yes', 'Civil Servant'),
+            ('no', 'Contractor'),
+        )
+
+    def queryset(self, request, queryset):
+        if self.value() == 'yes':
+            return queryset.filter(is_contractor=False)
+        elif self.value() == 'no':
+            return queryset.filter(is_contractor=True)
+
+
 class IsCurrentFilter(admin.SimpleListFilter):
     """
     this filter shows `is_current=True` by default
@@ -48,16 +69,23 @@ class IsCurrentFilter(admin.SimpleListFilter):
 class PersonAdmin(ReadOnlyAdmin):
     inlines = [RateInline]
     readonly_fields = ('avatar_tag', )
-    list_display = ('avatar_tag', 'name', 'job_title', 'is_contractor',
-                    'is_current')
+    list_display = ('avatar_tag', 'name', 'job_title',
+                    'contractor_civil_servant', 'is_current')
     search_fields = ('name', 'job_title')
-    list_filter = ('is_contractor', IsCurrentFilter)
+    list_filter = (IsCivilServantFilter, IsCurrentFilter)
     exclude = ['raw_data']
 
     def avatar_tag(self, obj):  # pragma: no cover
         return '<img src="{}" style="height:40px;"/>'.format(obj.avatar)
     avatar_tag.allow_tags = True
     avatar_tag.short_description = 'image'
+
+    def contractor_civil_servant(self, obj):
+        if obj.is_contractor:
+            return 'Contractor'
+        else:
+            return 'Civil Servant'
+    contractor_civil_servant.short_description = 'Contractor | Civil Servant'
 
 
 class RateAdmin(FinancePermissions, admin.ModelAdmin):

--- a/dashboard/apps/prototype/models.py
+++ b/dashboard/apps/prototype/models.py
@@ -21,9 +21,15 @@ class Person(models.Model):
     name = models.CharField(max_length=128)
     email = models.EmailField(null=True)
     avatar = models.URLField(null=True)
-    is_contractor = models.BooleanField(default=False)
+    is_contractor = models.BooleanField(
+        default=False,
+        verbose_name='is contractor?'
+    )
     job_title = models.CharField(max_length=128, null=True)
-    is_current = models.BooleanField(default=True)
+    is_current = models.BooleanField(
+        default=True,
+        verbose_name='is current staff?'
+    )
     raw_data = JSONField(null=True)
 
     def __str__(self):

--- a/dashboard/apps/prototype/tests/test_admin.py
+++ b/dashboard/apps/prototype/tests/test_admin.py
@@ -25,7 +25,7 @@ def test_is_civil_servant_filter(value, names):
     filter = IsCivilServantFilter(
         None, {'is_civil_servant': value}, Person, PersonAdmin)
     result = filter.queryset(None, Person.objects.all())
-    assert set([p.name for p in result]) == set(names)
+    assert {p.name for p in result} == set(names)
 
 
 @pytest.mark.parametrize('value,names', [
@@ -39,7 +39,7 @@ def test_is_current_staff_filter(value, names):
     filter = IsCurrentStaffFilter(
         None, {'is_current_staff': value}, Person, PersonAdmin)
     result = filter.queryset(None, Person.objects.all())
-    assert set([p.name for p in result]) == set(names)
+    assert {p.name for p in result} == set(names)
 
 
 @pytest.mark.parametrize('key,expected', [

--- a/dashboard/apps/prototype/tests/test_admin.py
+++ b/dashboard/apps/prototype/tests/test_admin.py
@@ -1,0 +1,55 @@
+# -*- coding: utf-8 -*-
+from model_mommy import mommy
+import pytest
+
+from ..admin import IsCivilServantFilter, IsCurrentStaffFilter, PersonAdmin
+from ..models import Person
+
+
+def create_fixtures():
+    p1 = mommy.make(Person, name='p1', is_current=True, is_contractor=True)
+    p2 = mommy.make(Person, name='p2', is_current=True, is_contractor=False)
+    p3 = mommy.make(Person, name='p3', is_current=False, is_contractor=True)
+    p4 = mommy.make(Person, name='p4', is_current=False, is_contractor=False)
+    return {'p1': p1, 'p2': p2, 'p3': p3, 'p4': p4}
+
+
+@pytest.mark.parametrize('value,names', [
+    ('yes', ['p2', 'p4']),
+    ('no',  ['p1', 'p3']),
+    (None,  ['p1', 'p2', 'p3', 'p4']),
+])
+@pytest.mark.django_db
+def test_is_civil_servant_filter(value, names):
+    create_fixtures()
+    filter = IsCivilServantFilter(
+        None, {'is_civil_servant': value}, Person, PersonAdmin)
+    result = filter.queryset(None, Person.objects.all())
+    assert set([p.name for p in result]) == set(names)
+
+
+@pytest.mark.parametrize('value,names', [
+    (None,   ['p1', 'p2']),
+    ('no',   ['p3', 'p4']),
+    ('all',  ['p1', 'p2', 'p3', 'p4']),
+])
+@pytest.mark.django_db
+def test_is_current_staff_filter(value, names):
+    create_fixtures()
+    filter = IsCurrentStaffFilter(
+        None, {'is_current_staff': value}, Person, PersonAdmin)
+    result = filter.queryset(None, Person.objects.all())
+    assert set([p.name for p in result]) == set(names)
+
+
+@pytest.mark.parametrize('key,expected', [
+    ('p1', 'Contractor'),
+    ('p2', 'Civil Servant'),
+    ('p3', 'Contractor'),
+    ('p4', 'Civil Servant'),
+])
+@pytest.mark.django_db
+def test_person_admin_contractor_civil_servant(key, expected):
+    people = create_fixtures()
+    admin = PersonAdmin(Person, None)
+    assert admin.contractor_civil_servant(people[key]) == expected


### PR DESCRIPTION
1. sync people `is_current` status from float.
2. only show current people by default, but can view all by choosing the options from the filter.
3. use labels 'civil servant', 'contractor' instead of boolean flags.
4. order by name by default.

<img width="1512" alt="screenshot 2016-06-14 14 27 42" src="https://cloud.githubusercontent.com/assets/640204/16044404/337cf2b6-323c-11e6-83ee-335ff1c51ae5.png">
