### PR TITLE
Feature/project life time

### DIFF
--- a/dashboard/apps/prototype/static/js/__tests__/project-test.js
+++ b/dashboard/apps/prototype/static/js/__tests__/project-test.js
@@ -12,13 +12,13 @@ const financial = {
   },
   '2016-02': {
     'contractor': '200.500',
-    'non-contractor': '100.20',
+    'non-contractor': '99.00',
     'budget': '800.00',
     'additional': '70.4'
   },
   '2016-03': {
     'contractor': '150.500',
-    'non-contractor': '150.20',
+    'non-contractor': '149.20',
     'budget': '900.00',
     'additional': '10.2'
   }
@@ -26,20 +26,27 @@ const financial = {
 
 describe('parseProjectFinancials', () => {
   it(`extracts and the converts the months and financial figures`, () => {
-    const parsed = parseProjectFinancials(financial, '2016-02-10');
+    const parsed = parseProjectFinancials(financial);
 
-    expect(parsed.months).toEqual([ '2016-01', '2016-02', '2016-03' ]);
-    expect(parsed.budget).toEqual([ 500, 800, 900 ]);
-
-    expect(parsed.pastMonths).toEqual([ '2016-01' ]);
-    expect(parsed.pastTotalCosts).toEqual([ 351.5 ]);
-    expect(parsed.pastCumulative).toEqual([ 351.5 ]);
-    expect(parsed.pastRemainings).toEqual([ 148.5 ]);
-
-    expect(parsed.futureMonths).toEqual([ '2016-02', '2016-03' ]);
-    expect(parsed.futureTotalCosts).toEqual([ 371.1, 310.9 ]);
-    expect(parsed.futureCumulative).toEqual([ 722.6, 1033.5 ]);
-
+    expect(Object.keys(parsed)).toEqual([ '2016-01', '2016-02', '2016-03' ]);
+    expect(parsed['2016-01']).toEqual({
+      budget: 500,
+      total: 351.5,
+      cumulative: 351.5,
+      remaining: 148.5
+    });
+    expect(parsed['2016-02']).toEqual({
+      budget: 800,
+      total: 369.9,
+      cumulative: 721.4,
+      remaining: 800 - 721.4  // float is not exactly 78.6
+    });
+    expect(parsed['2016-03']).toEqual({
+      budget: 900,
+      total: 309.9,
+      cumulative: 1031.3,
+      remaining: 900 - 1031.3  // float is not exactly 131.3
+    });
   });
 });
 

--- a/dashboard/apps/prototype/static/js/cumulative-graph.js
+++ b/dashboard/apps/prototype/static/js/cumulative-graph.js
@@ -211,6 +211,9 @@ export function plotCumulativeSpendings(project, showBurnDown, elem) {
     marker: {
       color: '#FFBF47',
       line: {width: 0}  // for ie9 only
+    },
+    line: {
+      dash: 'dot'
     }
   };
 

--- a/dashboard/apps/prototype/static/js/cumulative-graph.js
+++ b/dashboard/apps/prototype/static/js/cumulative-graph.js
@@ -130,29 +130,20 @@ function markingsForToday(range) {
 
 
 export function plotCumulativeSpendings(project, showBurnDown, elem) {
-  const { months,
-          budget,
-          pastMonths,
-          pastCumulative,
-          pastRemainings,
-          futureMonths,
-          futureCumulative,
-          futureRemainings } = parseProjectFinancials(project.financial);
-
-  // use current month + future months to ensure continuity
-  const index = pastMonths.length -1;
-  const currentPlusFutureMonths = [ pastMonths[ index ] ]
-    .concat(futureMonths);
-  const currentPlusFutureCumulative = [ pastCumulative[ index ] ]
-    .concat(futureCumulative);
-  const currentPlusFutureRemainings = [ pastRemainings[ index ] ]
-    .concat(futureRemainings);
+  const currentMonth = moment().format('YYYY-MM');
+  const lastMonth = moment().subtract(1, 'month').format('YYYY-MM');
+  const monthly = parseProjectFinancials(project.financial);
+  const months = Object.keys(monthly).sort();
+  const pastMonths = months
+    .filter(m => m < currentMonth);
+  const lastPlusFutureMonths = months
+    .filter(m => m >= lastMonth);
 
   const toLabel = m => endOfMonth(moment(m, 'YYYY-MM'));
 
   const actualCumulativeTrace = {
-    x: months.map(toLabel),
-    y: pastCumulative,
+    x: pastMonths.map(toLabel),
+    y: pastMonths.map(m => monthly[m].cumulative),
     name: 'Actual spend',
     type: 'scatter',
     yaxis: 'y',
@@ -162,8 +153,8 @@ export function plotCumulativeSpendings(project, showBurnDown, elem) {
     }
   };
   const actualRemainingTrace = {
-    x: months.map(toLabel),
-    y: pastRemainings,
+    x: pastMonths.map(toLabel),
+    y: pastMonths.map(m => monthly[m].remaining),
     name: 'Actual spend',
     type: 'scatter',
     yaxis: 'y',
@@ -174,8 +165,8 @@ export function plotCumulativeSpendings(project, showBurnDown, elem) {
   };
 
   const forecastCumulativeTrace = {
-    x: currentPlusFutureMonths.map(toLabel),
-    y: currentPlusFutureCumulative,
+    x: lastPlusFutureMonths.map(toLabel),
+    y: lastPlusFutureMonths.map(m => monthly[m].cumulative),
     name: 'Forecast spend',
     type: 'scatter',
     yaxis: 'y',
@@ -188,8 +179,8 @@ export function plotCumulativeSpendings(project, showBurnDown, elem) {
     }
   };
   const forecastRemainingTrace = {
-    x: currentPlusFutureMonths.map(toLabel),
-    y: currentPlusFutureRemainings,
+    x: lastPlusFutureMonths.map(toLabel),
+    y: lastPlusFutureMonths.map(m => monthly[m].remaining),
     name: 'Forecast spend',
     type: 'scatter',
     yaxis: 'y',
@@ -204,7 +195,7 @@ export function plotCumulativeSpendings(project, showBurnDown, elem) {
 
   const budgetTrace = {
     x: months.map(toLabel),
-    y: budget,
+    y: months.map(m => monthly[m].budget),
     name: 'Budget',
     type: 'scatter',
     yaxis: 'y',

--- a/dashboard/apps/prototype/static/js/cumulative-graph.js
+++ b/dashboard/apps/prototype/static/js/cumulative-graph.js
@@ -129,15 +129,13 @@ function markingsForToday(range) {
 }
 
 
-export function plotCumulativeSpendings(project, showBurnDown, elem) {
+export function plotCumulativeSpendings(project, showBurnDown, startDate, endDate, elem) {
   const currentMonth = moment().format('YYYY-MM');
   const lastMonth = moment().subtract(1, 'month').format('YYYY-MM');
   const monthly = parseProjectFinancials(project.financial);
   const months = Object.keys(monthly).sort();
-  const pastMonths = months
-    .filter(m => m < currentMonth);
-  const lastPlusFutureMonths = months
-    .filter(m => m >= lastMonth);
+  const pastMonths = months.filter(m => m < currentMonth);
+  const lastPlusFutureMonths = months.filter(m => m >= lastMonth);
 
   const toLabel = m => endOfMonth(moment(m, 'YYYY-MM'));
 
@@ -219,10 +217,7 @@ export function plotCumulativeSpendings(project, showBurnDown, elem) {
     data.push(budgetTrace);
   };
 
-  const range =  [
-    moment(startOfMonth(months[ 0 ])),
-    moment(months.slice(-1)[0]).endOf('month')
-  ];
+  const range =  [ moment(startDate), moment(endDate) ];
 
   const {shapes, annotations} = backgroundForPhases(project, range);
   const todayMarkings = markingsForToday(range);

--- a/dashboard/apps/prototype/static/js/project.js
+++ b/dashboard/apps/prototype/static/js/project.js
@@ -217,11 +217,7 @@ export class ProjectContainer extends Component {
     };
     // when startDate or endDate changes
     if (this.state.startDate != startDate || this.state.endDate != endDate) {
-      this.setState({hasData: false});
-      getProjectData(this.props.id, startDate, endDate, this.props.csrftoken)
-        .then(project => {
-          this.setState({project: project, hasData: true});
-        });
+      this.setState({startDate: startDate, endDate: endDate});
     };
   }
 
@@ -290,6 +286,8 @@ export class ProjectContainer extends Component {
           onChange={(e) => this.handleBurnDownChange(e)}
           project={this.state.project}
           showBurnDown={this.state.showBurnDown}
+          startDate={this.state.startDate}
+          endDate={this.state.endDate}
         />
       </div>
     );
@@ -351,10 +349,14 @@ class ProjectGraph extends Component {
     plotCumulativeSpendings(
       this.props.project,
       this.props.showBurnDown,
+      this.props.startDate,
+      this.props.endDate,
       this.container1
     );
     plotMonthlySpendings(
       this.props.project,
+      this.props.startDate,
+      this.props.endDate,
       this.container2
     );
   }
@@ -397,17 +399,14 @@ class ProjectGraph extends Component {
 /**
  * plot the graph for a project's monthly spendings
  */
-function plotMonthlySpendings(project, elem) {
-  const monthly = parseProjectFinancials(
-      project.financial);
+function plotMonthlySpendings(project, startDate, endDate, elem) {
+  const monthly = parseProjectFinancials(project.financial);
+  const months = Object.keys(monthly).sort()
+    .filter(m => endOfMonth(m) >= startDate && endOfMonth(m) <= endDate);
 
   const currentMonth = moment().format('YYYY-MM');
-  const pastMonths = Object.keys(monthly)
-    .filter(m => m < currentMonth)
-    .sort();
-  const futureMonths = Object.keys(monthly)
-    .filter(m => m >= currentMonth)
-    .sort();
+  const pastMonths = months.filter(m => m < currentMonth);
+  const futureMonths = months.filter(m => m >= currentMonth);
   const pastTotalCosts = pastMonths.map(
       m => monthly[m].total);
   const futureTotalCosts = futureMonths.map(


### PR DESCRIPTION
1. cumulative line should begin with spend up to start date not zero
2. When viewing 'entire project lifetime' timescale of graph should start on discovery start date and end on end date. (graph should not just show the time when there's money spent)
