### PR TITLE
transpancy for the bar chart

### DIFF
--- a/dashboard/assets/js/components/monthly-graph.js
+++ b/dashboard/assets/js/components/monthly-graph.js
@@ -28,7 +28,7 @@ export function plotMonthlySpendings(project, startDate, endDate, elem, isSmall)
     name: 'Actual spend',
     type: 'bar',
     marker: {
-      color: '#c0c2dc',
+      color: 'rgba(45, 52, 138, 0.3)',  // result in #c0c2dc with opacity
       line: {width: 0}  // for ie9 only
     }
   };
@@ -38,7 +38,7 @@ export function plotMonthlySpendings(project, startDate, endDate, elem, isSmall)
     name: 'Forecast spend',
     type: 'bar',
     marker: {
-      color: '#add1d1',
+      color: 'rgba(-238, 102, 102, 0.3)',  // result in #add1d1 with opacity
       line: {width: 0}  // for ie9 only
     }
   };


### PR DESCRIPTION
implements: https://www.pivotaltracker.com/story/show/130722305

transparency on the bar chart to make the coordinates visible.

new:
<img width="1292" alt="screenshot 2016-09-20 13 34 22" src="https://cloud.githubusercontent.com/assets/640204/18670265/0114160e-7f37-11e6-972b-fd1dced87c5d.png">

old:
<img width="1297" alt="screenshot 2016-09-20 13 36 48" src="https://cloud.githubusercontent.com/assets/640204/18670336/5319e136-7f37-11e6-9682-97a5f7ea5d8f.png">
