### PR TITLE
unique file names for each version of js and css using webpack loader

### DIFF
--- a/dashboard/settings/base.py
+++ b/dashboard/settings/base.py
@@ -60,6 +60,7 @@ INSTALLED_APPS = [
     'djcelery',
     'moj_template',
     'axes',
+    'webpack_loader',
 
     'dashboard.apps.prototype',
     'dashboard_auth',
@@ -250,6 +251,15 @@ if all([os.environ.get('SMTP_USER'),
 else:
     EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
 
+
+WEBPACK_LOADER = {
+    'DEFAULT': {
+        'CACHE': not DEBUG,
+        'BUNDLE_DIR_NAME': location('assets/dist/'),
+        'STATS_FILE': location('assets/dist/webpack-stats.json'),
+        'IGNORE': ['.+\.hot-update.js', '.+\.map']
+    }
+}
 # .local.py overrides all the common settings.
 try:
     from .local import *

--- a/dashboard/templates/common.html
+++ b/dashboard/templates/common.html
@@ -1,6 +1,7 @@
 {% extends 'moj_template_custom/moj_base.html' %}
 
 {% load staticfiles %}
+{% load render_bundle from webpack_loader %}
 
 {% block page_title %}
 
@@ -10,13 +11,13 @@
 
 {% block stylesheets %}
 
-    <link href="{% static 'dist/prototype.css' %}" rel="stylesheet" type="text/css"/>
-    <link href="{% static 'common/common.css' %}" rel="stylesheet" type="text/css"/>
+  {% render_bundle 'main' 'css' %}
+  <link href="{% static 'common/common.css' %}" rel="stylesheet" type="text/css"/>
 
 {% endblock %}
 
 {% block javascripts %}
-    <script src="{% static 'dist/prototype.js' %}"></script>
+  {% render_bundle 'main' 'js' %}
 {% endblock %}
 
 {% block before_content %}

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "react-spinkit": "^1.1.7",
     "react-tabs": "^0.7.0",
     "style-loader": "^0.13.1",
-    "webpack": "^1.13.0"
+    "webpack": "^1.13.0",
+    "webpack-bundle-tracker": "0.0.93"
   },
   "babel": {
     "presets": [

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -19,3 +19,4 @@ django-axes==2.2.0
 
 #Irat healthcheck and ping package
 git+https://github.com/ministryofjustice/django-moj-irat.git@4d54b86b1cb574fe787ba0fb8a992cf352f8eba6
+django-webpack-loader==0.3.3

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,7 +1,9 @@
 var path = require('path');
+var ExtractTextPlugin = require("extract-text-webpack-plugin");
+var BundleTracker = require('webpack-bundle-tracker');
 
 var directory = path.resolve(__dirname, "dashboard/assets");
-var ExtractTextPlugin = require("extract-text-webpack-plugin");
+var dist = path.resolve(directory, 'dist');
 
 module.exports = {
   entry: [
@@ -9,9 +11,9 @@ module.exports = {
     path.resolve(directory, 'js/main.js'),
   ],
   output: {
-    path: path.resolve(directory, 'dist'),
+    path: dist,
     publicPath: '/static/dist/',
-    filename: "prototype.js"
+    filename: "prototype.[hash].js"
   },
 
   module: {
@@ -35,7 +37,11 @@ module.exports = {
     ]
   },
   plugins: [
-    new ExtractTextPlugin("prototype.css")
+    new ExtractTextPlugin("prototype.[hash].css"),
+    new BundleTracker({
+      path: dist,
+      filename: 'webpack-stats.json'
+    })
   ],
   devtool: 'source-map'
 };


### PR DESCRIPTION
the file name now contains the hash of the file content, which make them unique.

![screenshot 2016-09-21 15 55 01](https://cloud.githubusercontent.com/assets/640204/18716186/c8d4902e-8013-11e6-9444-eb9f73884916.png)
![screenshot 2016-09-21 15 55 34](https://cloud.githubusercontent.com/assets/640204/18716219/ddc8e4c6-8013-11e6-8f96-55b9e6445cf0.png)
