### PR TITLE
cache product profile

### DIFF
--- a/dashboard/apps/dashboard/models.py
+++ b/dashboard/apps/dashboard/models.py
@@ -355,7 +355,7 @@ class Area(models.Model):
         return self.name
 
     def profile(self, product_ids=None, start_date=None, end_date=None,
-                freq=None):
+                freq='MS'):
         """
         get the profile of a service area in a time window.
         :param product_ids: a list of product_ids, if the value is not
@@ -669,7 +669,7 @@ class BaseProduct(models.Model):
             result['service_manager'] = self.area.manager.name
         return result
 
-    def profile(self, start_date=None, end_date=None, freq=None):
+    def profile(self, start_date=None, end_date=None, freq='MS'):
         """
         get the profile of a product group in a time window.
         :param start_date: start date of time window, a date object
@@ -678,6 +678,14 @@ class BaseProduct(models.Model):
         sub windows. value of freq should be an offset aliases supported by
         pandas date_range, e.g. MS for month start.
         :return: a dictionary representing the profile
+        """
+        return self._profile(start_date, end_date, freq)
+
+    @method_cache(timeout=24 * 60 * 60)
+    def _profile(self, start_date, end_date, freq):
+        """
+        this method does not have default value for params
+        hence more suitable for caching.
         """
         status = self.status()
         status = status.as_dict() if status else {}
@@ -826,7 +834,6 @@ class Product(BaseProduct, AditionalCostsMixin):
     def __str__(self):
         return self.name
 
-    @method_cache(timeout=24 * 60 * 60)
     def people_costs(self, start_date, end_date, contractor_only=False,
                      non_contractor_only=False):
         """

--- a/dashboard/apps/dashboard/tasks.py
+++ b/dashboard/apps/dashboard/tasks.py
@@ -10,7 +10,6 @@ from celery.task import periodic_task
 
 from .models import Product
 from .management.commands.helpers import logger
-from dashboard.libs.date_tools import slice_time_window
 
 
 def single_instance_task(timeout):
@@ -64,30 +63,4 @@ def cache_product(product_id):
     product = Product.objects.get(pk=product_id)
 
     logger.info('- generating caching for product "%s"', product)
-    logger.info('  * people costs monthly and on key dates')
-    product.profile(freq='MS')
-    try:
-        start_date = product.first_date
-        end_date = product.last_date
-    except ValueError:
-        return
-    # monthly people costs
-    time_windows = slice_time_window(
-        start_date, end_date, freq='MS', extend=True)
-    # people cost to key dates
-    time_windows += [
-        (start_date, key_date['date']) for key_date
-        in product.key_dates(freq='MS').values()
-    ]
-    for sdate, edate in time_windows:
-        product.people_costs(
-            sdate, edate,
-            ignore_cache=True)
-        product.people_costs(
-            sdate, edate,
-            contractor_only=True,
-            ignore_cache=True)
-        product.people_costs(
-            sdate, edate,
-            non_contractor_only=True,
-            ignore_cache=True)
+    product.profile()

--- a/dashboard/apps/dashboard/tests/test_product.py
+++ b/dashboard/apps/dashboard/tests/test_product.py
@@ -104,7 +104,7 @@ def test_product_without_tasks():
 
 @pytest.mark.django_db
 def test_product_profiles_without_frequency():
-    profile = make_product().profile()
+    profile = make_product().profile(freq=None)
     contractor = contractor_rate * man_days
     non_contractor = non_contractor_rate * man_days
     financial = {


### PR DESCRIPTION
this should address issue https://www.pivotaltracker.com/story/show/137455843

caching product profile is better than people spend. `product.profile()` is the only time consuming method to call for both list view and single page view of product. 

this should also fix the problem where the spend graph goes up and down, where spend for some months are updated but others not.