### PR TITLE
improved cache key generation

### DIFF
--- a/dashboard/apps/dashboard/models/product.py
+++ b/dashboard/apps/dashboard/models/product.py
@@ -302,9 +302,9 @@ class BaseProduct(models.Model):
             result['service_manager'] = self.area.manager.name
         return result
 
+    @method_cache(timeout=24 * 60 * 60)
     def profile(self, start_date=None, end_date=None, freq='MS',
-                calculation_start_date=None,
-                ignore_cache=False):
+                calculation_start_date=None):
         """
         get the profile of a product group in a time window.
         :param start_date: start date of time window, a date object
@@ -315,17 +315,6 @@ class BaseProduct(models.Model):
         :param calculation_start_date: date when calculation for people costs
         using tasks and rates start
         :return: a dictionary representing the profile
-        """
-        return self._profile(
-            start_date, end_date, freq,
-            calculation_start_date=calculation_start_date,
-            ignore_cache=ignore_cache)
-
-    @method_cache(timeout=24 * 60 * 60)
-    def _profile(self, start_date, end_date, freq, calculation_start_date):
-        """
-        this method does not have default value for params
-        hence more suitable for caching.
         """
         status = self.status()
         status = status.as_dict() if status else {}

--- a/dashboard/libs/cache_tools.py
+++ b/dashboard/libs/cache_tools.py
@@ -5,11 +5,139 @@ utilities for cache
 import logging
 from hashlib import sha224
 from functools import wraps
+import pickle
+import inspect
 
 from django.core.cache import cache
 from django.core.cache.backends.base import DEFAULT_TIMEOUT
 
 logger = logging.getLogger(__name__)
+
+
+def cache_key(function, instance, args, kwargs):
+    """
+    for this example function
+    >>> def add(x, y, z=3):
+    >>>     return x + y + z
+    all these forms should generate the same cache key:
+    >>> add(1, 2)
+    >>> add(1, 2, 3)
+    >>> add(1, 2, z=3)
+    >>> add(1, y=2, z=3)
+    >>> add(x=1, y=2, z=3)
+    and these should raise a TypeError
+    >>> add(1)  # missing argument
+    >>> add(1, 2, 3, z=4)  # multiple values
+    >>> add(1, 2, foo=4)  # unexpected keyword argument
+    :returns: str key
+    :raises: PickingError, ValueError
+    """
+    key_tuple = (
+        function.__module__,
+        function.__name__,
+        instance.id,
+        inspect_arguments(function, args, kwargs)
+    )
+    key = sha224(pickle.dumps(key_tuple)).hexdigest()
+    logger.debug('cache key %s for object %s ', key, key_tuple)
+    return key
+
+
+def inspect_positional_arguments(parameters, args):
+    """
+    inspect positional arguments
+    """
+    positional_or_keyword_params = [
+        (name, param)
+        for name, param in parameters.items()
+        if param.kind == param.POSITIONAL_OR_KEYWORD
+    ]
+    # *args
+    var_positional = [
+        (name, param)
+        for name, param in parameters.items()
+        if param.kind == param.VAR_POSITIONAL
+    ]
+
+    result = {
+        name: arg
+        for (name, param), arg in
+        zip(positional_or_keyword_params, args)
+    }
+
+    if var_positional:
+        name, param = var_positional[0]
+        result[name] = tuple(args[len(result):]) or param.empty
+    elif len(result) < len(args):
+        error = 'function takes at most {} positional arguments but {} were given'.format(
+            len(positional_or_keyword_params),
+            len(args)
+        )
+        raise TypeError(error)
+    return result
+
+
+def inspect_keyword_arguments(parameters, kwargs):
+    options = {
+        name: param
+        for name, param in parameters.items()
+        if param.kind in (param.POSITIONAL_OR_KEYWORD, param.KEYWORD_ONLY)
+    }
+
+    result = {
+        name: value for name, value in kwargs.items()
+        if name in options
+    }
+
+    for name, param in parameters.items():
+        # **kwargs
+        if param.kind == param.VAR_KEYWORD:
+            var_keyword = name, param
+            break
+    else:
+        var_keyword = None
+
+    if var_keyword:
+        name, param = var_keyword
+        result[name] = {
+            k: v for k, v in kwargs.items()
+            if k not in result
+        } or param.empty
+    elif len(result) < len(kwargs):
+        unexpected = set(kwargs.keys()) - set(result.keys())
+        error = 'unexpected keyword arguments {}'.format(','.join(unexpected))
+        raise TypeError(error)
+    return result
+
+
+def inspect_arguments(function, args, kwargs):
+    """
+    inspect function signature together with arguments by the caller.
+    :param function: function to whose arguments is to be inspected
+    :param args: tuple of positional arguments
+    :param kwargs: dict of keyword arguments
+    :returns: dict for the mapping of argument name to value
+    :raises: TypeError
+    """
+    parameters = inspect.signature(function).parameters
+    positional_args = inspect_positional_arguments(parameters, args)
+    keyword_args = inspect_keyword_arguments(parameters, kwargs)
+
+    overlap = set(positional_args.keys()) & set(keyword_args.keys())
+    if overlap:
+        raise TypeError('function got multiple values for arguments {}'.format(','.join(overlap)))
+
+    args_with_default_value = {}
+    missing_args = []
+    for name, param in parameters.items():
+        if name not in positional_args and name not in keyword_args:
+            if param.default != param.empty:
+                args_with_default_value[name] = param.default
+            else:
+                missing_args.append(name)
+    if missing_args:
+        raise TypeError('missing arguments {}'.format(','.join(missing_args)))
+    return {**positional_args, **keyword_args, **args_with_default_value}
 
 
 class method_cache:
@@ -26,28 +154,6 @@ class method_cache:
         """
         self.timeout = timeout
 
-    @staticmethod
-    def cache_key(method, instance, *args, **kwargs):
-        # TODO the key str should be more intelligent.
-        # for this example function
-        # @method_cache()
-        # def add(x, y, z=3):
-        #     return x + y + z
-        # all these forms should hit the same cache:
-        # add(1, 2)
-        # add(1, 2, 3)
-        # add(1, 2, z=3)
-        # add(1, y=2, z=3)
-        key_str = '{}:{}:{}:{}:{}'.format(
-            method.__module__,
-            method.__name__,
-            instance.id,
-            args,
-            kwargs)
-        key = sha224(key_str.encode()).hexdigest()
-        logger.debug('cache key %s for str %s ', key, key_str)
-        return key
-
     def __call__(self, method):
         """
         return: a wrapped function
@@ -55,14 +161,24 @@ class method_cache:
         @wraps(method)
         def wrapper(instance, *args, **kwargs):
             ignore_cache = kwargs.pop('ignore_cache', False)
-            key = self.cache_key(method, instance, *args, **kwargs)
+
+            try:
+                key = cache_key(
+                    method,
+                    instance,
+                    (None,) + args,  # None for first param `self`
+                    kwargs
+                )
+            except Exception as exc:
+                logger.exception('generate cache_key failed')
+                return method(instance, *args, **kwargs)
+
             if not ignore_cache and key in cache:
                 logger.debug('cache found for key %s', key)
                 return cache.get(key)
 
             if ignore_cache:
-                logger.debug('ignore cache')
-
+                logger.debug('cache ignored')
             result = method(instance, *args, **kwargs)
             logger.debug('cache generated for key %s', key)
             cache.set(key, result, self.timeout)

--- a/dashboard/libs/tests/test_cache.py
+++ b/dashboard/libs/tests/test_cache.py
@@ -1,4 +1,7 @@
 # -*- coding: utf-8 -*-
+from inspect import Parameter
+
+import pytest
 from unittest.mock import Mock, patch
 
 from django.core.cache import caches
@@ -6,6 +9,7 @@ from django.core.cache import caches
 from dashboard.libs import cache_tools
 
 locmem_cache = caches['caching-test']
+empty = Parameter.empty
 
 
 def echo(*arg, **kw):
@@ -27,8 +31,8 @@ class MockModel(object):
 
 
 def call_ten_times(method, instance, args, kw):
-    cache_key = cache_tools.method_cache.cache_key(
-        method, instance, *args, **kw)
+    cache_key = cache_tools.cache_key(
+        method, instance, args, kw)
     locmem_cache.delete(cache_key)
 
     for i in range(10):
@@ -81,3 +85,94 @@ def test_method_cache_applied_and_explictly_not_ignored():
     assert mock_obj.echo.call_count == 1
     kw.pop('ignore_cache')
     mock_obj.echo.assert_called_once_with(*args, **kw)
+
+
+@pytest.mark.parametrize('args, kwargs', [
+    ((1, 2), {}),
+    ((1, 2, 3), {}),
+    ((1, 2), {'z': 3}),
+    ((1,), {'y': 2, 'z': 3}),
+    ((), {'x': 1, 'y': 2, 'z': 3}),
+])
+def test_inspect_arguments_positional_or_keyword(args, kwargs):
+    def func(x, y, z=3):
+        pass
+
+    assert cache_tools.inspect_arguments(
+        func, args, kwargs
+    ) == {'x': 1, 'y': 2, 'z': 3}
+
+
+@pytest.mark.parametrize('args, kwargs', [
+    ((1, 2, 3, 4), {}),     # too many parameters
+    ((1,), {}),             # too few parameters
+    ((1, 2, 3), {'z': 4}),  # multiple values for z
+    ((1, 2, 3), {'a': 4}),  # unexpected argument a
+])
+def test_raise_for_inspect_arguments_positional_or_keyword(args, kwargs):
+    def func(x, y, z=3):
+        pass
+
+    with pytest.raises(TypeError):
+        cache_tools.inspect_arguments(func, args, kwargs)
+
+
+def test_inspect_arguments_var_positional():
+    def func(x, y, *args):
+        pass
+
+    assert cache_tools.inspect_arguments(
+        func, (1, 2, 3, 4), {}
+    ) == {'x': 1, 'y': 2, 'args': (3, 4)}
+
+
+def test_inspect_arguments_func_with_var_keyword():
+    def func(x, y, **kw):
+        pass
+
+    assert cache_tools.inspect_arguments(
+        func, (1, 2), {'kw1': 3, 'kw2': 4}
+    ) == {'x': 1, 'y': 2, 'kw': {'kw1': 3, 'kw2': 4}}
+
+
+@pytest.mark.parametrize('args, kwargs, expected', [
+    ((1,), {'y': 2, 'z': 1}, {'x': 1, 'y': 2, 'z': 1}),
+    ((1,), {'y': 2}, {'x': 1, 'y': 2, 'z': 1}),
+])
+def test_inspect_arguments_func_with_keyword_only_parameters(args, kwargs, expected):
+    def func(x, *, y, z=1):
+        pass
+    assert cache_tools.inspect_arguments(
+        func, args, kwargs
+    ) == expected
+
+
+@pytest.mark.parametrize('args, kwargs, expected', [
+    (
+        (1, 2),
+        {},
+        {'x': 1, 'y': 2, 'z': 3, 'args': empty, 'kw': empty}
+    ),
+    (
+        (1, 2, 3),
+        {},
+        {'x': 1, 'y': 2, 'z': 3, 'args': (3,), 'kw': empty}
+    ),
+    (
+        (1, 2, 3, 4, 5),
+        {'z': 6},
+        {'x': 1, 'y': 2, 'z': 6, 'args': (3, 4, 5), 'kw': empty}
+    ),
+    (
+        (1, 2, 3, 4, 5),
+        {'z': 6, 'kw1': 7, 'kw2': 8},
+        {'x': 1, 'y': 2, 'z': 6, 'args': (3, 4, 5), 'kw': {'kw1': 7, 'kw2': 8}}
+    ),
+])
+def test_inspect_arguments_func_mixed_kinds(args, kwargs, expected):
+    def func(x, y, *args, z=3, **kw):
+        pass
+
+    assert cache_tools.inspect_arguments(
+        func, args, kwargs
+    ) == expected


### PR DESCRIPTION
for this example function
```
@method_cache()
def add(x, y, z=3):
    return x + y + z
```
all these forms should generate the same cache key:
```
add(1, 2)
add(1, 2, 3)
add(1, 2, z=3)
add(1, y=2, z=3)
add(x=1, y=2, z=3)
```
and these should raise a TypeError
```
add(1)  # missing argument
add(1, 2, 3, z=4)  # multiple values
add(1, 2, foo=4)  # unexpected keyword argument
```